### PR TITLE
Add jQuery as AdminFileWidget Media dependency

### DIFF
--- a/filer/fields/file.py
+++ b/filer/fields/file.py
@@ -87,6 +87,8 @@ class AdminFileWidget(ForeignKeyRawIdWidget):
             ]
         }
         js = (
+            'admin/js/vendor/jquery/jquery.js',
+            'admin/js/jquery.init.js',
             'filer/js/libs/dropzone.min.js',
             'filer/js/addons/dropzone.init.js',
             'filer/js/addons/popup_handling.js',


### PR DESCRIPTION
Dropzone requires jQuery, so it should be listed in here. Otherwise the output order might be different.